### PR TITLE
fix: correct Category constructor parameter assignments and property …

### DIFF
--- a/backend/FinanceTrackerAPI/FinanaceTracker.Domain/Entities/Category.cs
+++ b/backend/FinanceTrackerAPI/FinanaceTracker.Domain/Entities/Category.cs
@@ -6,4 +6,18 @@ public class Category
     public required int Id { get; set; }
     public required string Name { get; set; }
     public Type type { get; set; } = typeof(Category);
+    public required string Description { get; set; }
+
+
+public Category(){}
+
+
+public Category(int id, string name, Type type, string description) 
+{
+    Id = id;
+    Name = name;
+    this.type = type;
+    Description = description;
+}
+
 }


### PR DESCRIPTION
- Updated the Category constructor to accept a description parameter and assign it to the Description property.
- Fixed the assignment of the type property by using this.type instead of Type, resolving the case-sensitivity issue.
- Removed invalid use of the required keyword in constructor parameters.